### PR TITLE
feat: support AoT compilation with nativescript-dev-webpack plugin

### DIFF
--- a/app.module.ts
+++ b/app.module.ts
@@ -1,0 +1,12 @@
+import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
+import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+
+import { AppComponent } from "./app.component";
+
+@NgModule({
+  declarations: [AppComponent],
+  bootstrap: [AppComponent],
+  imports: [NativeScriptModule],
+  schemas: [NO_ERRORS_SCHEMA],
+})
+export class AppModule {}

--- a/main.aot.ts
+++ b/main.aot.ts
@@ -1,0 +1,4 @@
+import { platformNativeScript } from "nativescript-angular/platform-static";
+import { AppModuleNgFactory } from "./app.module.ngfactory";
+
+platformNativeScript().bootstrapModuleFactory(AppModuleNgFactory);

--- a/main.ts
+++ b/main.ts
@@ -1,15 +1,4 @@
-import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { platformNativeScriptDynamic } from "nativescript-angular/platform";
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
-
-import { AppComponent } from "./app.component";
-
-@NgModule({
-  declarations: [AppComponent],
-  bootstrap: [AppComponent],
-  imports: [NativeScriptModule],
-  schemas: [NO_ERRORS_SCHEMA]
-})
-export class AppModule {}
+import { AppModule } from "./app.module";
 
 platformNativeScriptDynamic().bootstrapModule(AppModule);


### PR DESCRIPTION
Related to [#74](https://github.com/NativeScript/nativescript-dev-webpack/issues/74).

`AppModule` also has to be separated from `main.ts`  for compliance with the tutorial ([ch2](http://docs.nativescript.org/angular/tutorial/ng-chapter-2.html#23-starting-up), [ch3](http://docs.nativescript.org/angular/tutorial/ng-chapter-3.html#35-routing)).